### PR TITLE
Ignore weeks

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -2,6 +2,7 @@
     "courses": ["#SPLUS7A3292", "#SPLUS7A3280"],
     "icsPath": "kalender/informatik1.ics",
     "prefetchWeeks": 4,
+    "ignoreWeeks": 0,
 
     "titleBlacklist": [
         "Programmieren"

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const uniqueByKey = (arrOfObj, key) => flatten((new Map(arrOfObj.map(obj => [obj
 
 async function main(configPath) {
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    const baseDate = moment().tz("Europe/Berlin").startOf('week');
+    const baseDate = moment().tz("Europe/Berlin").startOf('week').add(config.ignoreWeeks, 'w');
 
     const events = flatten(await BPromise.map(xprod(config.courses, range(config.prefetchWeeks)), async ([course, weeksAhead]) => {
         const week = baseDate.clone().add(weeksAhead, 'weeks').weeks();


### PR DESCRIPTION
I added a value in the config.json to set a number of ignored weeks.
Instead of starting in the next calendar week, the parsing can start a few weeks later.
The default value is 0 and produces the same output as before.
Please review the changes before merging.